### PR TITLE
protect from segfault in the framework initializer

### DIFF
--- a/init.c
+++ b/init.c
@@ -15,9 +15,24 @@ __attribute__((constructor))
 static void initializer(int argc, char** argv, char** envp)
 {
     CFBundleRef bundle = CFBundleGetBundleWithIdentifier(CFSTR("org.fuse-t.fuse-t"));
+    if (bundle == NULL) {
+        fprintf(stderr, "Error: Failed to get bundle with identifier.\n");
+        return;
+    }
+
     CFURLRef bundleURL = CFBundleCopyResourcesDirectoryURL(bundle);
+    if (bundleURL == NULL) {
+        fprintf(stderr, "Error: Failed to get resources directory URL.\n");
+        return;
+    }
+
     char path[PATH_MAX];
-    CFURLGetFileSystemRepresentation(bundleURL, TRUE, (UInt8 *)path, PATH_MAX);
+    if (!CFURLGetFileSystemRepresentation(bundleURL, TRUE, (UInt8 *)path, PATH_MAX)) {
+        fprintf(stderr, "Error: Failed to get file system representation.\n");
+        CFRelease(bundleURL);
+        return;
+    }
+
     CFRelease(bundleURL);
     strcat(path, "/go-nfsv4");
     setenv("FUSE_NFSSRV_PATH", path, 1);


### PR DESCRIPTION
ensure that every step in locating the go-nfsv4 binary avoids crashing by validating expected inputs/outputs